### PR TITLE
Add New Documentation Template to Issues Template

### DIFF
--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -1,0 +1,27 @@
+name: "📑 Documentation Update"
+description: "Improve Documentation"
+title: "DOC:"
+labels: [documentation]
+body:
+  - type: textarea
+    attributes:
+      label: "What's wrong with the existing documentation"
+      description: "Which things do we need to add or delete"
+    validations:
+      required: true
+  - type: textarea
+    attributes:
+      label: "Add Screenshots"
+      description: "Add sufficient SS to explain your issue."
+    validations:
+      required: false
+
+  - type: checkboxes
+    attributes:
+      label: "Record"
+      options:
+        - label: "I agree to follow this project's Code of Conduct"
+          required: true
+        - label: "I'm a GSSOC'24 contributor"
+        - label: "I want to work on this issue"
+        

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -12,7 +12,7 @@ body:
   - type: textarea
     attributes:
       label: "Add Screenshots"
-      description: "Add sufficient SS to explain your issue."
+      description: "Add sufficient screenshot to explain your issue."
     validations:
       required: false
 

--- a/.github/ISSUE_TEMPLATE/documentation.yml
+++ b/.github/ISSUE_TEMPLATE/documentation.yml
@@ -22,6 +22,6 @@ body:
       options:
         - label: "I agree to follow this project's Code of Conduct"
           required: true
-        - label: "I'm a GSSOC'24 contributor"
+        - label: "I'm a GirlScript Summer of Code 2024 contributor"
         - label: "I want to work on this issue"
         


### PR DESCRIPTION
## Description-

This pull request adds a new template for documentation in the ISSUES TEMPLATE section. The goal is to provide a standardized format for reporting and addressing documentation-related issues, ensuring clarity and consistency across our project.

## Issues FIx
#12 

## How to Use?
- **Navigate to the Issues section:** Click on 'New Issue' and select the 'Documentation' template.
- **Fill in the required fields**: Provide a detailed description, specify the affected documentation, and suggest possible improvements.
- **Submit the issue**: Once all fields are filled out, submit the issue for review.

@avinashkranjan  I appreciate your consideration and look forward to your feedback.
