### PR TITLE
Implement Workflow for Auto-Commit on Issue Closure

### DIFF
--- a/.github/workflows/close-issues_autoComment.yml
+++ b/.github/workflows/close-issues_autoComment.yml
@@ -1,0 +1,29 @@
+name: Comment on Issue Close
+
+on:
+  issues:
+    types: [closed]
+
+jobs:
+  greet-on-close:
+    runs-on: ubuntu-latest
+    permissions:
+      issues: write
+    steps:
+      - name: Greet User
+        uses: actions/github-script@v5
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const issue = context.payload.issue;
+            const issueCreator = issue.user.login;
+            const issueNumber = issue.number;
+
+            const greetingMessage = `Hello @${issueCreator}! Your issue #${issueNumber} has been closed. Thank you for your contribution!`;
+
+            github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: greetingMessage
+            });


### PR DESCRIPTION
## Description:

I'm thrilled to submit this pull request introducing a new workflow that automates the commit process upon issue closure. This enhancement streamlines our development workflow, ensuring that changes are recorded promptly and accurately.

### Fixes #13 

## Usable
When the issues will close by you then the `github-actions` will automatic comment for issues close `paragraph`

@avinashkranjan Thank you for considering this enhancement. I eagerly await your feedback.

